### PR TITLE
CHG: exclude wx.cloud api

### DIFF
--- a/packages/@mycolorway/vest-core/src/wx-api.js
+++ b/packages/@mycolorway/vest-core/src/wx-api.js
@@ -39,7 +39,9 @@ const wechatSyncApis = [
   // 地图、系统、画布
   'createMapContext', 'getSystemInfoSync', 'getExtConfigSync', 'createCanvasContext',
   // 调试、基础
-  'getLogManager', 'canIUse'
+  'getLogManager', 'canIUse',
+  // 云开发
+  'cloud'
 ]
 
 const weworkSyncApis = []


### PR DESCRIPTION
> 云开发的 API 风格与框架组件和 API 风格一致，但同时支持回调风格和Promise风格。在传入 API 的 Object 参数中，如果传入了 success、fail、complete 字段，则我们认为是采用回调风格，API 方法调用不返回 Promise。如果传入 API 的 Object 参数中 success、fail、complete 这三个字段都不存在，则我们认为是采用Promise风格，API 方法调用返回一个 Promise，Promise resolve 的结果同传入 success 回调的参数，reject 的结果同传入 fail 的参数。

https://developers.weixin.qq.com/miniprogram/dev/wxcloud/guide/init.html