### PR TITLE
FIX: regenerator-runtime 编译路径问题

### DIFF
--- a/packages/@mycolorway/vest-cli/lib/tasks/build/babel/plugins/transform-runtime.js
+++ b/packages/@mycolorway/vest-cli/lib/tasks/build/babel/plugins/transform-runtime.js
@@ -30,14 +30,14 @@ module.exports = function({ types }) {
     visitor: {
       ReferencedIdentifier(path) {
         const { node, parent, scope } = path
-        if (node.name === 'regeneratorRuntime') {
-          path.replaceWith(
-            this.addDefaultImport(
-              'regenerator-runtime',
-              'regeneratorRuntime',
-            ),
-          )
-        }
+        // if (node.name === 'regeneratorRuntime') {
+        //   path.replaceWith(
+        //     this.addDefaultImport(
+        //       'regenerator-runtime',
+        //       'regeneratorRuntime',
+        //     ),
+        //   )
+        // }
       }
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15647853/127324646-89f87133-1a18-42ce-a69e-7ad5dbf0afd2.png)
本地实测，可以正常编译了